### PR TITLE
fix: declare `eslint`, `vue` and `vite` as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@unhead/vue": "1.8.9",
     "chromatic": "10.2.0",
     "conventional-changelog-conventionalcommits": "7.0.2",
-    "eslint": "8.56.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
     "eslint-plugin-storybook": "0.6.15",
@@ -57,18 +56,22 @@
     "typescript": "5.3.3",
     "unplugin-auto-import": "0.17.3",
     "unplugin-vue-components": "0.26.0",
-    "vite": "5.0.11",
     "vite-plugin-vuetify": "2.0.1",
-    "vue": "3.4.8",
     "vue-i18n": "9.9.0",
     "vue-router": "4.2.5",
     "vuetify": "3.4.10"
   },
   "devDependencies": {
-    "nuxt": "3.9.1"
+    "nuxt": "3.9.1",
+    "vue": "3.4.8",
+    "vite": "5.0.11",
+    "eslint": "8.56.0"
   },
   "peerDependencies": {
-    "nuxt": "^3.7.4"
+    "eslint": "^8.56.0",
+    "nuxt": "^3.7.4",
+    "vue": "^3.4.8",
+    "vite": "^5.0.11"
   },
   "author": {
     "name": "jojomatik",


### PR DESCRIPTION
Declare `eslint`, `vue` and `vite` as peer dependencies and require them as a (dev-)dependency of all projects using `nuxt-bundle`.